### PR TITLE
fixes to make CDAConsole compile

### DIFF
--- a/libs/mod/cdaconsole.mod
+++ b/libs/mod/cdaconsole.mod
@@ -1,5 +1,6 @@
 IMPLEMENTATION MODULE CDAConsole;
 
+IMPORT ASCII;
 FROM Terminal IMPORT AssignWrite, AssignRead;
 
 (*$Pascal+*)
@@ -19,12 +20,14 @@ BEGIN
   CDWrite(ch);
 END CDAWrite;
 
-PROCEDURE CDARead(VAR ch: CHAR);
+PROCEDURE CDARead(VAR ch: CHAR; VAR done: BOOLEAN);
 BEGIN
   IF CDCharacterPresent() THEN
     CDRead(ch);
+    done := TRUE;
   ELSE
     ch := ASCII.nul;
+    done := FALSE;
   END;
 END CDARead;
 


### PR DESCRIPTION
```
    CDAConsole_CDARead
   27 :     ch := ASCII.nul;
                       ^  identifier not declared or not visible
   27 :     ch := ASCII.nul;
                        ^  type should be a record
   27 :     ch := ASCII.nul;
                          ^  incompatible assignment
   34 :   AssignRead(CDARead);
                            ^  procedure has fewer parameters than the formal type list
```