### PR TITLE
Bug fix for the generated shutdown code

### DIFF
--- a/libs/asm/m2lib.asm
+++ b/libs/asm/m2lib.asm
@@ -1706,16 +1706,16 @@ M2Lib__Terminated   ENTRY
                     DC      H'00 00'
 
 M2Lib__QuitParms    ENTRY
-M2Lib__quitPCount   DC      H'00 00'
-M2Lib__quitPath     DC      H'00 00 00 00'
-M2Lib__quitFlags    DC      H'40 00'
+M2Lib__quitPCount   DC      I2'2'
+M2Lib__quitPath     DC      I4'0'
+M2Lib__quitFlags    DC      I2'$4000'
 
 M2Lib__CloseParms   ENTRY
-                    DC      H'00 01'        ;pcount = 1
-                    DC      H'00 00'        ;refNum = 0, close all files
+                    DC      I2'1'           ;pcount = 1
+                    DC      I2'0'           ;refNum = 0, close all files
 
 M2Lib__SetLInfoDCB  ENTRY
-                    DC      H'00 0B'        ;pcount = 11
+                    DC      I2'11'          ;pcount = 11
                     DC      H'00 00 00 00'  ;sfile = NIL
                     DC      H'00 00 00 00'  ;dfile = NIL
                     DC      H'00 00 00 00'  ;parms = NIL

--- a/m2hm.mod
+++ b/m2hm.mod
@@ -4700,7 +4700,7 @@ BEGIN
     AddBytesToObjectFile(3);
     GenGlobalOp(PEA, 'M2Lib__CloseParms', 0, 0, 2);
     AddBytesToObjectFile(3);
-    PutDPReference(PEA, 2024H, 3);
+    PutDPReference(PEA, 2014H, 3);
     PutLongReference(JSL, 0E100B0H, 4);
 
     GenGlobalOp(LDA+ABSLONG, '~USER_ID', 0, 0, 3);


### PR DESCRIPTION
The generated shutdown code was calling FormatGS ($2024) instead of CloseGS ($2014)

However, neither would actually do anything since the parameter count was byteswapped so gs/os returned an invalid pcount error.