### PR TITLE
Enable record generation in the debugger records.

### DIFF
--- a/m2debug.mod
+++ b/m2debug.mod
@@ -112,10 +112,16 @@ BEGIN
   END;
 *)
   IF typ^.form IN sStrForm{Bool, Char, Card, Int, Enum, LCard, Double, Range,
-                           Real, LongReal, String} THEN
+                           Real, LongReal, String, Record} THEN
     RETURN TRUE;
-  ELSIF typ^.form IN sStrForm{Array, Pointer} THEN
+  ELSIF typ^.form = Array THEN
     RETURN BaseOK(typ^.ElemTyp);
+  ELSIF typ^.form = Pointer THEN
+    IF typ^.PBaseTyp^.form = Undef THEN
+      RETURN TRUE;
+    ELSE
+      RETURN BaseOK(typ^.PBaseTyp);
+    END;
   ELSE
     RETURN FALSE;
   END;
@@ -133,7 +139,7 @@ BEGIN
     CASE typ^.form OF
       Bool:
         type := 09H;
-    | Char:
+    | Char, Undef:
         type := 08H;
     | Card:
         type := 41H;


### PR DESCRIPTION
There is a comment in the bug list about recursive records with m2debug. 

This:

```
arec = RECORD
  next:  POINTER TO arec;
END;
```

caused a problem for me since `next` has an undefined type and is skipped.  Since it's the last field in the record and it's skipped, the record doesn't have an end-of-field marker which causes problems.

(Trying to access `next` will cause a compiler error because it's undefined so I guess that isn't supported in Modula/2).

Something like this worked as expected.
```
arecPtr = POINTER TO arec;
arec = RECORD
  next:  arecPtr;
END;
```

Undefined pointers are now treated as `POINTER TO CHAR` for debug record generation purposes.  This is consistent with how function pointers are treated.  (ORCA/C generates `void *` and function pointers as a `POINTER TO INTEGER`)